### PR TITLE
ENG-468: 64MB Multipart Chunksize

### DIFF
--- a/scripts/boto3/multithread_upload/uh_upload.py
+++ b/scripts/boto3/multithread_upload/uh_upload.py
@@ -55,7 +55,8 @@ class uploader:
             self.transfer_config = boto3.s3.transfer.TransferConfig(
                 multipart_threshold = 16 * 1024 * 1024 * 1024 * 1024)
         else:
-            self.transfer_config = boto3.s3.transfer.TransferConfig()
+            self.transfer_config = boto3.s3.transfer.TransferConfig(
+                multipart_chunksize = 64 * 1024 * 1024)
 
         self.s3 = boto3.client('s3', endpoint_url=config.url[0], config=s3_cnf,
             aws_access_key_id=AWS_KEY_ID, aws_secret_access_key=AWS_KEY_SECRET)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Solving issue:
<!--- If it fixes an open issue, please link to the issue here. -->

https://linear.app/ultihash/issue/ENG-468/stability-test-change-the-multipart-chunk-size

## Description
<!--- Describe your approach on solution in detail, use tl;dr and bulleted points -->

Stability test is very slow since the multipart upload, integrates large amounts of data in 8 MB chunks. We should increase the size to 64MB to improve the performance of stability test.

### Screenshots or updated diagram (if appropriate):
<!--- instead of 1000 words, diagram shows the best. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected or change in the architecture)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation and architecture diagram accordingly.

## What reviewers should especially pay attention to (if applicable):
* 