### PR TITLE
Remove the plain text AWS credentials

### DIFF
--- a/scripts/boto3/multithread_download/README.md
+++ b/scripts/boto3/multithread_download/README.md
@@ -21,6 +21,9 @@ Install all requirements:
 ```
 $> pip install --requirement requirements.txt
 ```
+Before executing the script make sure the AWS credentials are properly set:
+- as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set)
+- as [instance profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-methods)
 
 # Usage
 To download a bucket from an UH cluster running locally:

--- a/scripts/boto3/multithread_download/uh_download.py
+++ b/scripts/boto3/multithread_download/uh_download.py
@@ -9,9 +9,6 @@ import sys
 import time
 import tqdm
 
-AWS_KEY_ID="key-id"
-AWS_KEY_SECRET="secret"
-
 def parse_args():
     parser = argparse.ArgumentParser(
         prog='UH download',
@@ -46,8 +43,7 @@ class downloader:
                 'mode': 'standard'
             })
 
-        self.s3 = boto3.client('s3', endpoint_url=config.url[0], config=s3_cnf,
-            aws_access_key_id=AWS_KEY_ID, aws_secret_access_key=AWS_KEY_SECRET)
+        self.s3 = boto3.client('s3', endpoint_url=config.url[0], config=s3_cnf)
         self.config = config
         self.progress = None
         self.count_buffer = 0

--- a/scripts/boto3/multithread_upload/README.md
+++ b/scripts/boto3/multithread_upload/README.md
@@ -20,6 +20,9 @@ Install all requirements:
 ```
 $> pip install --requirement requirements.txt
 ```
+Before executing the script make sure the AWS credentials are properly set:
+- as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set)
+- as [instance profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-methods)
 
 # Usage
 To upload a folder to an UH cluster running locally:

--- a/scripts/boto3/multithread_upload/uh_upload.py
+++ b/scripts/boto3/multithread_upload/uh_upload.py
@@ -11,9 +11,6 @@ import sys
 import time
 import tqdm
 
-AWS_KEY_ID="key-id"
-AWS_KEY_SECRET="secret"
-
 def parse_args():
     parser = argparse.ArgumentParser(
         prog='UH upload',
@@ -64,8 +61,7 @@ class uploader:
                 multipart_chunksize = config.multipart_chunksize,
                 max_concurrency=config.connections)
 
-        self.s3 = boto3.client('s3', endpoint_url=config.url[0], config=s3_cnf,
-            aws_access_key_id=AWS_KEY_ID, aws_secret_access_key=AWS_KEY_SECRET)
+        self.s3 = boto3.client('s3', endpoint_url=config.url[0], config=s3_cnf)
         self.progress = None
         self.count_buffer = 0
         self.quiet = config.quiet

--- a/scripts/boto3/simple/README.md
+++ b/scripts/boto3/simple/README.md
@@ -23,6 +23,9 @@ Install all requirements:
 ```
 $> pip install --requirement requirements.txt
 ```
+Before executing the script make sure the AWS credentials are properly set:
+- as [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set)
+- as [instance profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-methods)
 
 # Script Usage
 

--- a/scripts/boto3/simple/simple_download.py
+++ b/scripts/boto3/simple/simple_download.py
@@ -12,8 +12,7 @@ if __name__ == "__main__":
 
     # connection to UltiHash S3 service
     uh_url = sys.argv[1]
-    uh_service = boto3.client('s3', endpoint_url=uh_url,
-        aws_access_key_id='', aws_secret_access_key='')
+    uh_service = boto3.client('s3', endpoint_url=uh_url)
 
     # all data will be queried from this bucket
     source_bucket_name = "bucket"

--- a/scripts/boto3/simple/simple_upload.py
+++ b/scripts/boto3/simple/simple_upload.py
@@ -12,8 +12,7 @@ if __name__ == "__main__":
 
     # connection to UltiHash S3 service
     uh_url = sys.argv[1]
-    uh_service = boto3.client('s3', endpoint_url=uh_url,
-        aws_access_key_id='', aws_secret_access_key='')
+    uh_service = boto3.client('s3', endpoint_url=uh_url)
 
     # all data will be stored under
     target_bucket_name = "bucket"

--- a/scripts/boto3/ultihash_info/get_effective_size.py
+++ b/scripts/boto3/ultihash_info/get_effective_size.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Jun 10 11:22:39 2024
-
-@author: massi
-"""
-
 import argparse
 import boto3
 import botocore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Solving issue:
<!--- If it fixes an open issue, please link to the issue here. -->
Related to [ENG-505](https://linear.app/ultihash/issue/ENG-505/avoid-leaving-aws-credentials-in-the-upload-scripts)

## Description
<!--- Describe your approach on solution in detail, use tl;dr and bulleted points -->
- removed the plain text AWS credentials from the boto3 scripts
- it has been done not only due to security reasons, but also due to the functional ones: during the performance test the scripts have to be used to work with the native S3. That requires passing the AWS credentials securely: via environment variables or instance profiles. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- ran the scripts and made sure they work