### PR TITLE
Enable creation of persistent volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,15 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+

--- a/docs/setup-ultihash-on-aws.md
+++ b/docs/setup-ultihash-on-aws.md
@@ -67,7 +67,10 @@ The next step is installation of the essential Kubernetes controllers on the pro
 - `Nginx Ingress` - exposes UltiHash outside of the EKS cluster with a Network Load Balancer 
 - `Load Balancer Controller` - provisions a Network Load Balancer for the `Nginx Ingress` controller
 - `Karpenter` - provisions EC2 instances on-demand to host UltiHash workloads
-- `Local Path Provisioner` - CSI controller that automatically provisions persistent volumes for the UltiHash workfloads. These volumes are bound to the NVMe SSD instance store available on the machines provisioned by `Karpenter`
+- `Local Path Provisioner` - CSI controller that automatically provisions non-persistent volumes for the UltiHash workfloads. These volumes are bound to the NVMe SSD instance store available on the machines provisioned by `Karpenter`
+- `EBS CSI Driver` - CSI controller that automatically provisions persistent volumes the UltiHash workfloads. The volumes are based on `gp3` storage class and optimised in terms of performance 
+
+ :ledger: Note, that the volumes provisioned by `Local Path Provisioner` are non persistent! Once EC2 instance is removed, all its accosiated volumes will be removed as well. If during the testing, it is required to remove the EC2 instances without loosing their volumes, use `EBS CSI Driver` instead.
 
 Perform the following actions to deploy the Terraform project:
 1. Update the `bucket name` and its `region` in the [main.tf](../scripts/terraform/aws/eks-cluster-controllers/main.tf) with the onces done at [the previous step](#setup-s3-bucket-for-terraform-states).

--- a/docs/setup-ultihash-on-aws.md
+++ b/docs/setup-ultihash-on-aws.md
@@ -67,10 +67,10 @@ The next step is installation of the essential Kubernetes controllers on the pro
 - `Nginx Ingress` - exposes UltiHash outside of the EKS cluster with a Network Load Balancer 
 - `Load Balancer Controller` - provisions a Network Load Balancer for the `Nginx Ingress` controller
 - `Karpenter` - provisions EC2 instances on-demand to host UltiHash workloads
-- `Local Path Provisioner` - CSI controller that automatically provisions non-persistent volumes for the UltiHash workfloads. These volumes are bound to the NVMe SSD instance store available on the machines provisioned by `Karpenter`
+- `Local Path Provisioner` - CSI controller that automatically provisions non-persistent volumes for the UltiHash workloads. These volumes are bound to the NVMe SSD instance store available on the machines provisioned by `Karpenter`
 - `EBS CSI Driver` - CSI controller that automatically provisions persistent volumes the UltiHash workfloads. The volumes are based on `gp3` storage class and optimised in terms of performance 
 
- :ledger: Note, that the volumes provisioned by `Local Path Provisioner` are non persistent! Once EC2 instance is removed, all its accosiated volumes will be removed as well. If during the testing, it is required to remove the EC2 instances without loosing their volumes, use `EBS CSI Driver` instead.
+ :ledger: Note, that the volumes provisioned by `Local Path Provisioner` are non persistent! Once EC2 instance is removed, all its accosiated volumes will be removed as well. If during the testing, it is required to remove the EC2 instances to save the costs without loosing their volumes, use `EBS CSI Driver` instead. This requires modification of the UltiHash Helm values, which will be explaned [at a later step](#ultihash-installation).
 
 Perform the following actions to deploy the Terraform project:
 1. Update the `bucket name` and its `region` in the [main.tf](../scripts/terraform/aws/eks-cluster-controllers/main.tf) with the onces done at [the previous step](#setup-s3-bucket-for-terraform-states).
@@ -88,7 +88,7 @@ Perform the following actions to deploy the Terraform project:
 The last step is installation of UltiHash. For this purpose use [this Terraform project](../scripts/terraform/aws/ultihash/).
 Perform the following actions to deploy the Terraform project:
 1. Update the `bucket name` and its `region` in the [main.tf](../scripts/terraform/aws/ultihash/main.tf) with the ones done at [the previous step](#setup-s3-bucket-for-terraform-states).
-2. Update the configuration in [config.tfvars](../scripts/terraform/aws/ultihash/config.tfvars) with the credentials received from UltiHash representatives. The credentials in the `config.tfvars` are mocked. The helm values for UltiHash are found [here](../scripts/terraform/aws/ultihash/ultihash-helm-values.yaml). Feel free to scale the number of `entrypoint`, `storage`, and `deduplicator` instance if required.
+2. Update the configuration in [config.tfvars](../scripts/terraform/aws/ultihash/config.tfvars) with the credentials received from UltiHash representatives. The credentials in the `config.tfvars` are mocked. The helm values for UltiHash are found [here](../scripts/terraform/aws/ultihash/ultihash-helm-values.yaml). The only required change in the Helm values is the storage class for `etcd`, `storage`, `deduplicator`, and `database`. In case persistence is not required, use `local-path` storage class. Otherwise select `gp3-high-performance` (in case of `etcd` it will be `ebs-csi-gp3`). Feel free also to scale the number of `entrypoint`, `storage`, and `deduplicator` instances if required.
 3. Initialize and apply the Terraform project
    ```
    cd scripts/terraform/aws/ultihash

--- a/docs/setup-ultihash-on-aws.md
+++ b/docs/setup-ultihash-on-aws.md
@@ -111,6 +111,7 @@ To uninstall all previously deployed AWS resources follow these steps:
    ```
    cd scripts/terraform/aws/ultihash
    terraform destroy --var-file config.tfvars
+   kubectl delete pvc --all
    ``` 
 2. Uninstall Kubernetes controllers:
    ```

--- a/scripts/terraform/aws/eks-cluster-controllers/.terraform.lock.hcl
+++ b/scripts/terraform/aws/eks-cluster-controllers/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudposse/utils" {
+  version     = "1.24.0"
+  constraints = ">= 0.17.0"
+  hashes = [
+    "h1:WxNuI1iVxZ44jvBrKnNHwhMwVv3eISr7uRf3MMPhUSU=",
+    "zh:34caad909caa152517a869262fa1baa01b43d93d262065122d1e88f356edbfe9",
+    "zh:3b9185c3c32bcb66287bb9ca6a5fdddf158b913a4de6fd84904dddcf3e33b5d2",
+    "zh:4b7903d391e88c1aa2a760969c04362a6443e2ef58f89e61c1409f53c375d120",
+    "zh:520c4c1d9945e5285c513ce0d53996c93df8ce9acf17a57751728437f797818a",
+    "zh:6e1400d0a8d62a7c3673d88700a50201bdf4cf1a510c5e07d00937e8a553bf08",
+    "zh:7c322b878e3b7e7383f8ca4bb198e54bd7a671be29a459e43b2fcde9cf5f31dd",
+    "zh:7e7a8211f902647da04dfe7532c75e8cd189201e3ad92f88427777d6675baf42",
+    "zh:b07838332865c053a455e8dae99f0c38f1b7382860742844c6f2dd0212287d52",
+    "zh:b2f63b5b457bd51e759df700d86d0e00eb11586500ccbf1ff7cb08fb383f3cf0",
+    "zh:bffdbbf353594413b56ed1e6a2ad30a5daa3e1295a7b5ff8181bf9f16fc2c294",
+    "zh:d061ea37bac659d27f9b59c39827d5b8d6577dc7c3c368d5341786630f800a77",
+    "zh:d103e5de75e63be945a1179171de1a84badcc4b1c44e64df38185e22ca0368d5",
+    "zh:d8a0fc2f32944a6da66f14873519e92754812caa9d4847eb7686222d00c2da36",
+    "zh:daa841737a645d4c8d45f7efbd1b23a401430b9f7dbc15b92dcb632ad0ce5c78",
+  ]
+}
+
 provider "registry.terraform.io/gavinbunney/kubectl" {
   version     = "1.14.0"
   constraints = ">= 1.9.4"
@@ -20,7 +42,7 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.59.0"
-  constraints = ">= 3.35.0, ~> 5.0"
+  constraints = ">= 3.35.0, >= 4.19.0, ~> 5.0, >= 5.34.0"
   hashes = [
     "h1:pe+3OIuutpyF0eSRzhv2CEh1Getm8xNBSFoeTA6AGlA=",
     "zh:077f41a15057d01d833d7438322adf9b507d17ac0c8e1287430a305b6e609775",
@@ -43,7 +65,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.12.1"
-  constraints = ">= 1.0.0, 2.12.1, < 3.0.0"
+  constraints = ">= 1.0.0, >= 2.6.0, 2.12.1, < 3.0.0"
   hashes = [
     "h1:sgYI7lwGqJqPopY3NGmhb1eQ0YbH8PIXaAZAmnJrAvw=",
     "zh:1d623fb1662703f2feb7860e3c795d849c77640eecbc5a776784d08807b15004",
@@ -63,7 +85,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.26.0"
-  constraints = ">= 1.10.0, 2.26.0, < 3.0.0"
+  constraints = ">= 1.10.0, >= 2.11.0, 2.26.0, < 3.0.0"
   hashes = [
     "h1:MMxX/EY9AEGwp5DbGQ+LTd3c9YmjwrnPJHLlyc9u0eU=",
     "zh:3f8ee1bffab1ba4f6ae549daae1648974214880d3606b6821cb0aceb365284a4",

--- a/scripts/terraform/aws/eks-cluster-controllers/controllers-values/nginx-ingress.yaml
+++ b/scripts/terraform/aws/eks-cluster-controllers/controllers-values/nginx-ingress.yaml
@@ -15,7 +15,7 @@ controller:
       https: http
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-name: ultihash-test
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing  # Use 'internal' to provision internal NLB
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internal  # Use 'internet-facing' to provision a public NLB
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /healthz

--- a/scripts/terraform/aws/eks-cluster-controllers/controllers.tf
+++ b/scripts/terraform/aws/eks-cluster-controllers/controllers.tf
@@ -17,6 +17,20 @@ resource "helm_release" "local-path-provisioner" {
   create_namespace = true
 }
 
+module "ebs-csi-driver" {
+  source  = "lablabs/eks-ebs-csi-driver/aws"
+  version = "0.1.0"
+
+  cluster_identity_oidc_issuer     = data.terraform_remote_state.eks_cluster.outputs.cluster_oidc_issuer_url
+  cluster_identity_oidc_issuer_arn = data.terraform_remote_state.eks_cluster.outputs.cluster_oidc_provider_arn
+
+  helm_repo_url      = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver"
+  helm_chart_name    = "aws-ebs-csi-driver"
+  helm_chart_version = "2.27.0"
+
+  namespace = "kube-system"
+}
+
 module "load-balancer-controller" {
   source  = "DNXLabs/eks-lb-controller/aws"
   version = "0.9.0"

--- a/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/directory.node-pool.yaml
+++ b/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/directory.node-pool.yaml
@@ -26,4 +26,4 @@ spec:
           effect: NoSchedule
   disruption:
     consolidationPolicy: WhenEmpty
-    consolidateAfter: 30m
+    consolidateAfter: 10m

--- a/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/entrypoint.node-pool.yaml
+++ b/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/entrypoint.node-pool.yaml
@@ -26,4 +26,4 @@ spec:
           effect: NoSchedule
   disruption:
     consolidationPolicy: WhenEmpty
-    consolidateAfter: 30m
+    consolidateAfter: 10m

--- a/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/storage.node-pool.yaml
+++ b/scripts/terraform/aws/eks-cluster-controllers/karpenter-manifests/storage.node-pool.yaml
@@ -26,4 +26,4 @@ spec:
           effect: NoSchedule
   disruption:
     consolidationPolicy: WhenEmpty
-    consolidateAfter: 30m
+    consolidateAfter: 10m

--- a/scripts/terraform/aws/eks-cluster-controllers/main.tf
+++ b/scripts/terraform/aws/eks-cluster-controllers/main.tf
@@ -16,11 +16,15 @@ terraform {
       source  = "hashicorp/template"
       version = "2.2.0"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
   }
   backend "s3" {
-    bucket = "terraform-state-test-setup"                # REQUIRED TO CHANGE: Update the bucket name for the Terraform state 
+    bucket = "terraform-state-test-setup" # REQUIRED TO CHANGE: Update the bucket name for the Terraform state 
     key    = "eks-cluster-controllers/terraform.tfstate"
-    region = "eu-central-1"                              # REQUIRED TO CHANGE: Update the bucket region for the Terraform state 
+    region = "eu-central-1" # REQUIRED TO CHANGE: Update the bucket region for the Terraform state 
   }
 }
 
@@ -32,9 +36,9 @@ data "terraform_remote_state" "eks_cluster" {
   backend = "s3"
 
   config = {
-    bucket = "terraform-state-test-setup"        # REQUIRED TO CHANGE: Update the bucket name for the Terraform state
+    bucket = "terraform-state-test-setup" # REQUIRED TO CHANGE: Update the bucket name for the Terraform state
     key    = "eks-cluster/terraform.tfstate"
-    region = "eu-central-1"                      # REQUIRED TO CHANGE: Update the bucket region for the Terraform state
+    region = "eu-central-1" # REQUIRED TO CHANGE: Update the bucket region for the Terraform state
   }
 }
 
@@ -51,6 +55,16 @@ provider "helm" {
 }
 
 provider "kubernetes" {
+  host                   = data.terraform_remote_state.eks_cluster.outputs.cluster_endpoint
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.eks_cluster.outputs.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--region", var.aws_region, "--cluster-name", data.terraform_remote_state.eks_cluster.outputs.cluster_name]
+    command     = "aws"
+  }
+}
+
+provider "kubectl" {
   host                   = data.terraform_remote_state.eks_cluster.outputs.cluster_endpoint
   cluster_ca_certificate = base64decode(data.terraform_remote_state.eks_cluster.outputs.cluster_certificate_authority_data)
   exec {

--- a/scripts/terraform/aws/ultihash/ultihash-helm-values.yaml
+++ b/scripts/terraform/aws/ultihash/ultihash-helm-values.yaml
@@ -20,7 +20,7 @@ etcd:
       effect: "NoSchedule"
   persistence:
     size: 100Gi
-    storageClass: local-path   # Replace with 'ebs-csi-gp3' to create persistent volume
+    storageClass: local-path   # REQUIRED TO CHANGE: Replace with 'ebs-csi-gp3' to create persistent volume
 
 entrypoint:
   replicas: 1
@@ -56,7 +56,7 @@ entrypoint:
 
 storage:
   replicas: 2
-  storageClass: local-path    # Use 'gp3-high-performance' to create persistent volume       
+  storageClass: local-path    # REQUIRED TO CHANGE: Use 'gp3-high-performance' to create persistent volume       
   storageSize: 5Ti
   affinity:
     podAntiAffinity:
@@ -79,7 +79,7 @@ storage:
 
 deduplicator:
   replicas: 2
-  storageClass: local-path   # Replace with 'gp3-high-performance' to create persistent volume
+  storageClass: local-path   # REQUIRED TO CHANGE: Replace with 'gp3-high-performance' to create persistent volume
   storageSize: 300Gi
   affinity:
     podAntiAffinity:
@@ -112,7 +112,7 @@ database:
       effect: "NoSchedule"
 
     persistence:
-      storageClass: local-path    # Replace with 'gp3-high-performance' to create persistent volume 
+      storageClass: local-path    # REQUIRED TO CHANGE: Replace with 'gp3-high-performance' to create persistent volume 
       size: 300Gi
 
 databaseInit:

--- a/scripts/terraform/aws/ultihash/ultihash-helm-values.yaml
+++ b/scripts/terraform/aws/ultihash/ultihash-helm-values.yaml
@@ -20,7 +20,7 @@ etcd:
       effect: "NoSchedule"
   persistence:
     size: 100Gi
-    storageClass: local-path
+    storageClass: local-path   # Replace with 'ebs-csi-gp3' to create persistent volume
 
 entrypoint:
   replicas: 1
@@ -56,8 +56,8 @@ entrypoint:
 
 storage:
   replicas: 2
-  storageClass: local-path          
-  storageSize: 7Ti
+  storageClass: local-path    # Use 'gp3-high-performance' to create persistent volume       
+  storageSize: 5Ti
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -79,8 +79,8 @@ storage:
 
 deduplicator:
   replicas: 2
-  storageClass: local-path
-  storageSize: 1Ti
+  storageClass: local-path   # Replace with 'gp3-high-performance' to create persistent volume
+  storageSize: 300Gi
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -112,8 +112,8 @@ database:
       effect: "NoSchedule"
 
     persistence:
-      storageClass: local-path
-      size: 1Ti
+      storageClass: local-path    # Replace with 'gp3-high-performance' to create persistent volume 
+      size: 300Gi
 
 databaseInit:
   nodeSelector:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Solving issue:
<!--- If it fixes an open issue, please link to the issue here. -->
Enabled creation of persistent volumes. Related to [ENG-597](https://linear.app/ultihash/issue/ENG-597/select-the-ultihash-setup-on-aws-that-suits-ericsson)

## Description
<!--- Describe your approach on solution in detail, use tl;dr and bulleted points -->
- added EBS CSI driver to provision persistent volumes. Configured GP3 for the persistent volumes. Enabled GP3 using the best IOPS and throughput to maximize the disk performance.
- made the Netwok Load Balancer internal by default
- updated `.gitignore` to avoid pushing local Terraform artifacts to Github
- updated the documentation
- updated the UltiHash Helm values correspondingly

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- deployed the code in the staging AWS account
- made sure everything worked as intended