### PR TITLE
ENG-618 use relative path instead of absolute path as object key

### DIFF
--- a/scripts/boto3/multithread_download/uh_download.py
+++ b/scripts/boto3/multithread_download/uh_download.py
@@ -69,7 +69,10 @@ class downloader:
                 yield entry
 
     def push(self, bucket, key):
-        local_path = self.config.path / bucket / key
+        if (self.config.path == pathlib.Path('.')):
+            local_path = self.config.path / bucket / key
+        else:
+            local_path = self.config.path / key
         return self.threads.submit(self.download, bucket, key, local_path)
 
     def set_total(self, total):

--- a/scripts/boto3/multithread_download/uh_download.py
+++ b/scripts/boto3/multithread_download/uh_download.py
@@ -69,10 +69,7 @@ class downloader:
                 yield entry
 
     def push(self, bucket, key):
-        if (self.config.path == pathlib.Path('.')):
-            local_path = self.config.path / bucket / key
-        else:
-            local_path = self.config.path / key
+        local_path = self.config.path / bucket / key
         return self.threads.submit(self.download, bucket, key, local_path)
 
     def set_total(self, total):


### PR DESCRIPTION
## Solving issue:
https://linear.app/ultihash/issue/ENG-618/use-relative-path-instead-of-absolute-path-as-object-key

## Description
- the upload script now uses the relative path as object key
- otherwise, the absolute path will overwrite the originally uploaded date on download

## How has this been tested?
- multiple upload/download test on dev machine

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected or change in the architecture)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation and architecture diagram accordingly.

## What reviewers should especially pay attention to (if applicable):
* 