### PR TITLE
Minor fixes to prevent possible errors

### DIFF
--- a/scripts/terraform/aws/eks-cluster-controllers/controllers-values/nginx-ingress.yaml
+++ b/scripts/terraform/aws/eks-cluster-controllers/controllers-values/nginx-ingress.yaml
@@ -1,8 +1,5 @@
 controller:
   kind: DaemonSet
-  nodeSelector:
-    workload-type: entrypoint
-    kubernetes.io/os: linux
   tolerations:
     - key: "purpose"
       operator: "Equal"

--- a/scripts/terraform/aws/ultihash/config.tfvars
+++ b/scripts/terraform/aws/ultihash/config.tfvars
@@ -5,3 +5,5 @@ registry_password = "test-user-password"  # REQUIRED TO CHANGE: Password for reg
 
 ultihash_license = "Test-License:10240:Bplb7lZQIK+mIXyPsasadsaARSDrakfds7tdvrcASbndpL43axS7Ccd9TyuL4v03zHsFzPOyW7sL+uouBw=="  # REQUIRED TO CHANGE: UltiHash license
 monitoring_token = "8tEFwDsduD6gSHM2"     # REQUIRED TO CHANGE: UltiHash monitoring token
+
+helm_chart_installation_timeout = 600     # Time to install the UltiHash helm chart. Increase only in case of the "context deadline exceeded" error

--- a/scripts/terraform/aws/ultihash/ultihash.tf
+++ b/scripts/terraform/aws/ultihash/ultihash.tf
@@ -37,6 +37,7 @@ resource "helm_release" "ultihash" {
   name       = "ultihash"
   repository = "oci://registry.ultihash.io/stable"
   chart      = "ultihash-cluster"
+  timeout    = var.helm_chart_installation_timeout
 
   namespace = "default"
 

--- a/scripts/terraform/aws/ultihash/variables.tf
+++ b/scripts/terraform/aws/ultihash/variables.tf
@@ -24,3 +24,8 @@ variable "monitoring_token" {
   type        = string
   sensitive   = true
 }
+
+variable "helm_chart_installation_timeout" {
+  description = "Time to install the UltiHash helm chart"
+  type = number
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Solving issue:
<!--- If it fixes an open issue, please link to the issue here. -->
Introduced multiple fixes that eliminate the risk of encountering some errors during UltiHash deployment on AWS

## Description
<!--- Describe your approach on solution in detail, use tl;dr and bulleted points -->
- made the Nginx Ingress controller deployable on any EKS node to prevent possible errors with Ingress validation hook during UltiHash deployment
- increased the helm chart installation timeout to prevent possible "context deadline exceeded" error 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- applied the Terraform code and made sure it works as intended